### PR TITLE
Create cdshook-patient-consent-consult

### DIFF
--- a/test-script/cdshook-patient-consent-consult
+++ b/test-script/cdshook-patient-consent-consult
@@ -16,9 +16,9 @@ printf %s\\n
 curl  -X POST -H "Content-Type: application/json" -d '{"hook": "patient-consent-consult","hookInstance": "...","context": { "patientId": { "system": "http://hl7.org/fhir/sid/us-medicare","value": "0000-000-0000" },"scope" : "research","purposeOfUse": "TREAT", "actor": [      {        "system": "sample-system",        "value": "sample-id"      }    ]}}' $TARGET_HOST/cds-services/patient-consent-consult
 
 printf %s\\n
-printf "Testing patient-consent-consult using scope code: patient privacy"
+printf "Testing patient-consent-consult using scope code: patient-privacy"
 printf %s\\n
-curl  -X POST -H "Content-Type: application/json" -d '{"hook": "patient-consent-consult","hookInstance": "...","context": { "patientId": { "system": "http://hl7.org/fhir/sid/us-medicare","value": "0000-000-0000" },"scope" : "patient privacy","purposeOfUse": "TREAT", "actor": [      {        "system": "sample-system",        "value": "sample-id"      }    ]}}' $TARGET_HOST/cds-services/patient-consent-consult
+curl  -X POST -H "Content-Type: application/json" -d '{"hook": "patient-consent-consult","hookInstance": "...","context": { "patientId": { "system": "http://hl7.org/fhir/sid/us-medicare","value": "0000-000-0000" },"scope" : "patient-privacy","purposeOfUse": "TREAT", "actor": [      {        "system": "sample-system",        "value": "sample-id"      }    ]}}' $TARGET_HOST/cds-services/patient-consent-consult
 
 printf %s\\n
 printf "Testing patient-consent-consult using scope code: treatment"


### PR DESCRIPTION
New folder called "test-scripts", and new bash shell script called "cdshook-patient-consent-consult" were created to test the CDS Hook interface.  The curl commands are using these scope codes for testing: adr, research, patient privacy, and treatment.

To run the test script, from the command line prompt, issue this command:  
./cdshook-patient-consent-consult

Please note:  There is an error when testing the scope code for "patient privacy" shown below:
_Testing patient-consent-consult using scope code: patient privacy
{"httpCode":400,"error":"bad_request","errorMessage":"Invalid request: .context.scope should be equal to one of the allowed values"}_