### PR TITLE
Feature/support content class and clinical codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The response object is similar to the following example:
               "code":"REDACT"
             },
             "parameters":{
-              "labels":[
+              "codes":[
                 {
                   "system":"http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
                   "code":"R"
@@ -110,8 +110,8 @@ Each obligation object has an `id` attribute which identifies the obligation and
 
 | Obligation ID  | Description          | 
 | :---           |     :---             | 
-| `labels`       | Any resources marked with these security labels must be redacted. In other words, access is permitted except to any resource marked with the security labels specifies by this parameter.|
-|`exceptAnyOfLabels`  | All resources other than the ones marked with one (or more) of these security labels must be redacted. In other words, access is only permitted to the resources marked by the security labels specified in this parameter, and access to resources marked with other security labels is not authorized. The array is interpreted disjunctively, meaning that access to a resource bearing _any_ (and not _all_) of the labels in this array is authorized.|
+| `codes`       | Any resources associated with these codes (e.g., tagged with these security labels) must be redacted. In other words, access is permitted except to any resource associated with the codes identified by this attribute.|
+|`exceptAnyOfCodes`  | All resources other than the ones associated with these codes (e.g., marked with one or more of these security labels) must be redacted. In other words, access is only permitted to the resources associated with the codes identified by this attribute, and not authorized otherwise. The array is interpreted disjunctively, meaning that access to a resource associated with _any_ (and not _all_) of the codes in this array is authorized.|
 
 ## XACML Interface
 The XACML interface is based on a limited implementation of the [XACML JSON Profile](https://docs.oasis-open.org/xacml/xacml-json-http/v1.1/os/xacml-json-http-v1.1-os.html) and resides at the following endpoint:
@@ -196,7 +196,7 @@ The response from the XACML interface is similar to the following example:
           },
           "AttributeAssignment":[
             {
-              "AttributeId":"labels",
+              "AttributeId":"codes",
               "Value":[
                 {
                   "system":"http://terminology.hl7.org/CodeSystem/v3-Confidentiality",

--- a/lib/consent-processor.js
+++ b/lib/consent-processor.js
@@ -68,7 +68,7 @@ function denyOverrideDecisionCombiner(currentCandidate, thisDecision) {
       : currentCandidate.decision === NO_CONSENT
       ? thisDecision
       : currentCandidate;
-  
+
   const obligations =
     decision === CONSENT_DENY
       ? []
@@ -102,8 +102,8 @@ async function consentDecision(entry, query) {
   );
 
   const provisionsDecisions = await Promise.all(provisionsDecisionPromises);
-  
-  const finalDecision = provisionsDecisions.reduce(
+
+  const rawFinalDecision = provisionsDecisions.reduce(
     denyOverrideDecisionCombiner,
     {
       decision,
@@ -111,10 +111,58 @@ async function consentDecision(entry, query) {
     }
   );
 
+  const finalDecision = combineObligations(rawFinalDecision);
+
   return {
     ...finalDecision,
     dateTime: entry.resource.dateTime,
     id: entry.fullUrl
+  };
+}
+
+function combineObligations(decision) {
+  const obligations = decision.obligations;
+  const obligationsGroupedById = _.mapValues(
+    _.groupBy(obligations, obligation => JSON.stringify(obligation.id)),
+    bucket => bucket.map(item => item.parameters)
+  );
+
+  const rawCombinedObligations = _.mapValues(
+    obligationsGroupedById,
+    parameters => ({
+      codes: parameters.reduce(
+        (acc, thisOne) => _.union(acc, _.get(thisOne, "codes")),
+        []
+      ),
+      exceptAnyOfCodes: parameters.reduce(
+        (acc, thisOne) => _.union(acc, _.get(thisOne, "exceptAnyOfCodes")),
+        []
+      )
+    })
+  );
+
+  const removeEmptyCodeProperties = obligation =>
+    obligation.parameters.codes.length
+      ? {
+          id: obligation.id,
+          parameters: { codes: obligation.parameters.codes }
+        }
+      : {
+          id: obligation.id,
+          parameters: {
+            exceptAnyOfCodes: obligation.parameters.exceptAnyOfCodes
+          }
+        };
+
+  const combinedObligations = Object.keys(rawCombinedObligations)
+    .map(key => ({
+      id: JSON.parse(key),
+      parameters: _.get(rawCombinedObligations, key)
+    }))
+    .map(removeEmptyCodeProperties);
+  return {
+    decision: decision.decision,
+    obligations: combinedObligations
   };
 }
 

--- a/lib/consent-provisions.js
+++ b/lib/consent-provisions.js
@@ -76,17 +76,22 @@ async function processProvision(provision, query, fullUrl) {
   const initialDecision =
     match && permit ? CONSENT_PERMIT : match ? CONSENT_DENY : NO_CONSENT;
   
-  const securityLabels = _.castArray(provision.securityLabel);
-
-  const finalDecision = securityLabels[0] ? NO_CONSENT : initialDecision;
+  const finalDecision = willHaveObligations(provision)
+    ? NO_CONSENT
+    : initialDecision;
 
   return {
     decision: finalDecision,
-    obligations: securityLabelObligations(initialDecision, provision)
+    obligations: determineObligations(initialDecision, provision)
   };
 }
 
-function securityLabelObligations(decision, provision) {
+function willHaveObligations(provision) {
+  const securityLabels = _.castArray(provision.securityLabel);
+  return securityLabels[0];
+}
+
+function determineObligations(decision, provision) {
   const securityLabels = _.castArray(provision.securityLabel);
 
   const obligation =
@@ -95,7 +100,7 @@ function securityLabelObligations(decision, provision) {
       : decision === CONSENT_DENY
       ? CONSENT_OBLIGATIONS.SEC_LABELS.EXCEPT(securityLabels)
       : null;
-  
+
   return securityLabels[0] && obligation ? [obligation] : [];
 }
 

--- a/lib/consent-provisions.js
+++ b/lib/consent-provisions.js
@@ -75,7 +75,7 @@ async function processProvision(provision, query, fullUrl) {
 
   const initialDecision =
     match && permit ? CONSENT_PERMIT : match ? CONSENT_DENY : NO_CONSENT;
-  
+
   const finalDecision = willHaveObligations(provision)
     ? NO_CONSENT
     : initialDecision;
@@ -90,9 +90,13 @@ function willHaveObligations(provision) {
   const securityLabels = _.castArray(provision.securityLabel);
   const contentClasses = _.castArray(provision.class);
   const clinicalCodes = _.castArray(_.get(provision, "code.coding"));
-  const allCodes = _.concat(securityLabels, contentClasses, clinicalCodes);
+  const allCodes = _.concat(
+    securityLabels,
+    contentClasses,
+    clinicalCodes
+  ).filter(code => code);
 
-  return allCodes[0];
+  return allCodes.length;
 }
 
 function determineObligations(decision, provision) {
@@ -113,7 +117,7 @@ function determineObligations(decision, provision) {
       ? CONSENT_OBLIGATIONS.CODES.EXCEPT(allCodes)
       : null;
 
-  return securityLabels[0] && obligation ? [obligation] : [];
+  return allCodes.length && obligation ? [obligation] : [];
 }
 
 function fhirBaseFromFullResourceUrl(fullUrl) {

--- a/lib/consent-provisions.js
+++ b/lib/consent-provisions.js
@@ -88,17 +88,29 @@ async function processProvision(provision, query, fullUrl) {
 
 function willHaveObligations(provision) {
   const securityLabels = _.castArray(provision.securityLabel);
-  return securityLabels[0];
+  const contentClasses = _.castArray(provision.class);
+  const clinicalCodes = _.castArray(_.get(provision, "code.coding"));
+  const allCodes = _.concat(securityLabels, contentClasses, clinicalCodes);
+
+  return allCodes[0];
 }
 
 function determineObligations(decision, provision) {
   const securityLabels = _.castArray(provision.securityLabel);
+  const contentClasses = _.castArray(provision.class);
+  const clinicalCodes = _.castArray(_.get(provision, "code.coding"));
+
+  const allCodes = _.concat(
+    securityLabels,
+    contentClasses,
+    clinicalCodes
+  ).filter(entry => entry);
 
   const obligation =
     decision === CONSENT_PERMIT
-      ? CONSENT_OBLIGATIONS.SEC_LABELS.ONLY(securityLabels)
+      ? CONSENT_OBLIGATIONS.CODES.ONLY(allCodes)
       : decision === CONSENT_DENY
-      ? CONSENT_OBLIGATIONS.SEC_LABELS.EXCEPT(securityLabels)
+      ? CONSENT_OBLIGATIONS.CODES.EXCEPT(allCodes)
       : null;
 
   return securityLabels[0] && obligation ? [obligation] : [];

--- a/lib/consent-valuesets.js
+++ b/lib/consent-valuesets.js
@@ -49,13 +49,13 @@ const CONSENT_OBLIGATIONS = {
     ONLY: labels => ({
       id: REDACT_CODE,
       parameters: {
-        exceptAnyOfLabels: labels
+        exceptAnyOfCodes: labels
       }
     }),
     EXCEPT: labels => ({
       id: REDACT_CODE,
       parameters: {
-        labels: labels
+        codes: labels
       }
     })
   }

--- a/lib/consent-valuesets.js
+++ b/lib/consent-valuesets.js
@@ -45,7 +45,7 @@ const REDACT_CODE = {
 };
 
 const CONSENT_OBLIGATIONS = {
-  SEC_LABELS: {
+  CODES: {
     ONLY: labels => ({
       id: REDACT_CODE,
       parameters: {

--- a/schemas/patient-consent-consult-hook-response.schema.json
+++ b/schemas/patient-consent-consult-hook-response.schema.json
@@ -67,13 +67,13 @@
                     "parameters": {
                       "type": "object",
                       "properties": {
-                        "labels": {
+                        "codes": {
                           "type": "array",
                           "items": {
                             "$ref": "#/definitions/system-code"
                           }
                         },
-                        "exceptAnyOfLabels": {
+                        "exceptAnyOfCodes": {
                           "type": "array",
                           "items": {
                             "$ref": "#/definitions/system-code"

--- a/test/controllers/patient-consent-consult.test.js
+++ b/test/controllers/patient-consent-consult.test.js
@@ -207,7 +207,7 @@ it("should return 200 and an array including a consent permit card with obligati
                 code: "REDACT"
               },
               parameters: {
-                labels: [
+                codes: [
                   {
                     system:
                       "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",

--- a/test/controllers/xacml.test.js
+++ b/test/controllers/xacml.test.js
@@ -150,7 +150,7 @@ it("should return 200 and a consent permit response with obligations when a cons
             },
             AttributeAssignment: [
               {
-                AttributeId: "labels",
+                AttributeId: "codes",
                 Value: [
                   {
                     system:

--- a/test/fixtures/consents/consent-boris-deny-restricted-clinical-code.json
+++ b/test/fixtures/consents/consent-boris-deny-restricted-clinical-code.json
@@ -1,0 +1,88 @@
+{
+  "resourceType": "Consent",
+  "status": "active",
+  "text": {
+    "status": "additional",
+    "div": "optin but deny access to any resources containing the LOINC code indicating `substance abuse` to Organization/54."
+  },
+  "scope": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/consentscope",
+        "code": "patient-privacy"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "59284-6"
+        }
+      ]
+    }
+  ],
+  "patient": {
+    "reference": "Patient/52",
+    "display": "Betterhalf, Boris"
+  },
+  "dateTime": "2019-11-01",
+  "organization": [
+    {
+      "reference": "Organization/53"
+    }
+  ],
+  "policyRule": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "OPTIN"
+      }
+    ]
+  },
+  "provision": {
+    "period": {
+      "start": "2019-11-01",
+      "end": "2022-01-01"
+    },
+    "provision": [
+      {
+        "type": "deny",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org/",
+              "code": "42828-4"
+            }
+          ]
+        },
+        "actor": [
+          {
+            "role": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "IRCP"
+                }
+              ]
+            },
+            "reference": {
+              "reference": "Organization/54"
+            }
+          }
+        ],
+        "action": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/consentaction",
+                "code": "access"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/consents/consent-boris-deny-restricted-content-class.json
+++ b/test/fixtures/consents/consent-boris-deny-restricted-content-class.json
@@ -1,0 +1,92 @@
+{
+  "resourceType": "Consent",
+  "status": "active",
+  "text": {
+    "status": "additional",
+    "div": "optin but deny access to everything restricted as well as any MedicationStatement resources to Organization/54."
+  },
+  "scope": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/consentscope",
+        "code": "patient-privacy"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "59284-6"
+        }
+      ]
+    }
+  ],
+  "patient": {
+    "reference": "Patient/52",
+    "display": "Betterhalf, Boris"
+  },
+  "dateTime": "2019-11-01",
+  "organization": [
+    {
+      "reference": "Organization/53"
+    }
+  ],
+  "policyRule": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "OPTIN"
+      }
+    ]
+  },
+  "provision": {
+    "period": {
+      "start": "2019-11-01",
+      "end": "2022-01-01"
+    },
+    "provision": [
+      {
+        "type": "deny",
+        "securityLabel": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
+            "code": "R"
+          }
+        ],
+        "class": [
+          {
+            "system": "http://hl7.org/fhir/resource-types",
+            "code": "MedicationStatement"
+          }
+        ],
+        "actor": [
+          {
+            "role": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "IRCP"
+                }
+              ]
+            },
+            "reference": {
+              "reference": "Organization/54"
+            }
+          }
+        ],
+        "action": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/consentaction",
+                "code": "access"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/lib/consent-processor.test.js
+++ b/test/lib/consent-processor.test.js
@@ -269,7 +269,7 @@ it("active optin consent with security label provision", async () => {
           code: "REDACT"
         },
         parameters: {
-          labels: [
+          codes: [
             {
               system:
                 "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
@@ -321,7 +321,7 @@ it("active optin consent with array of security label provisions", async () => {
           code: "REDACT"
         },
         parameters: {
-          labels: [
+          codes: [
             {
               system:
                 "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
@@ -336,7 +336,7 @@ it("active optin consent with array of security label provisions", async () => {
           code: "REDACT"
         },
         parameters: {
-          labels: [
+          codes: [
             {
               system:
                 "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",

--- a/test/lib/consent-processor.test.js
+++ b/test/lib/consent-processor.test.js
@@ -322,35 +322,25 @@ it("active optin consent with array of security label provisions", async () => {
           code: "REDACT"
         },
         parameters: {
-          codes: [
+          codes: expect.arrayContaining([
             {
               system:
                 "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
               code: "R"
-            }
-          ]
-        }
-      },
-      {
-        id: {
-          system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-          code: "REDACT"
-        },
-        parameters: {
-          codes: [
+            },
             {
               system:
                 "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
               code: "V"
             }
-          ]
+          ])
         }
       }
     ])
   );
 });
 
-it.only("active optin consent with security label and content class provisions", async () => {
+it("active optin consent with security label and content class provisions", async () => {
   expect.assertions(2);
 
   setupMockOrganization(

--- a/test/lib/consent-processor.test.js
+++ b/test/lib/consent-processor.test.js
@@ -25,7 +25,6 @@ const NOT_YET_VALID_PRIVACY_CONSENT = _.set(
 
 const ACTIVE_RESEARCH_CONSENT = require("../fixtures/consents/consent-boris-research.json");
 const ACTIVE_PRIVACY_OPTOUT_CONSENT = require("../fixtures/consents/consent-boris-optout.json");
-const ACTIVE_PRIVACY_CONSENT_WITH_CONTENT_CLASS_PROVISION = require("../fixtures/consents/consent-boris-deny-restricted-content-class");
 const ACTIVE_PRIVACY_CONSENT_WITH_SEC_LABEL_PROVISION = require("../fixtures/consents/consent-boris-deny-restricted-label.json");
 const ACTIVE_PRIVACY_CONSENT_WITH_PROVISION_ARRAY = require("../fixtures/consents/consent-boris-provision-array.json");
 
@@ -342,6 +341,7 @@ it("active optin consent with array of security label provisions", async () => {
 
 it("active optin consent with security label and content class provisions", async () => {
   expect.assertions(2);
+  const ACTIVE_PRIVACY_CONSENT_WITH_CONTENT_CLASS_PROVISION = require("../fixtures/consents/consent-boris-deny-restricted-content-class");
 
   setupMockOrganization(
     `/${_.get(
@@ -388,6 +388,58 @@ it("active optin consent with security label and content class provisions", asyn
             {
               system: "http://hl7.org/fhir/resource-types",
               code: "MedicationStatement"
+            }
+          ]
+        }
+      }
+    ])
+  );
+});
+
+it("active optin consent with clinical code provisions", async () => {
+  expect.assertions(2);
+  const ACTIVE_PRIVACY_CONSENT_WITH_CLINICAL_CODE_PROVISION = require("../fixtures/consents/consent-boris-deny-restricted-clinical-code");
+
+  setupMockOrganization(
+    `/${_.get(
+      ACTIVE_PRIVACY_CONSENT_WITH_CLINICAL_CODE_PROVISION,
+      "provision.provision[0].actor[0].reference.reference"
+    )}`,
+    ORGANIZATION,
+    2
+  );
+
+  const decision = await processDecision(
+    [
+      {
+        fullUrl: `${CONSENT_FHIR_SERVERS[0]}/Consent/1`,
+        resource: ACTIVE_PRIVACY_CONSENT_WITH_CLINICAL_CODE_PROVISION
+      }
+    ],
+    {
+      patientId: {
+        system: "http://hl7.org/fhir/sid/us-medicare",
+        value: "0000-000-0000"
+      },
+      scope: "patient-privacy",
+      purposeOfUse: "TREAT",
+      actor: [ORGANIZATION.identifier[0]]
+    }
+  );
+
+  expect(decision.decision).toEqual("CONSENT_PERMIT");
+  expect(decision.obligations).toEqual(
+    expect.arrayContaining([
+      {
+        id: {
+          system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          code: "REDACT"
+        },
+        parameters: {
+          codes: [
+            {
+              system: "http://loinc.org/",
+              code: "42828-4"
             }
           ]
         }


### PR DESCRIPTION
Adding support for provisions that make exceptions based on the content to be shared and clinical codes.

@ferret1964 If you are aware of any real-world consent samples with these provisions please share so that I can add them as fixture. 

@ddecouteau please review but don't merge I'm still working on this to add test coverage and consent samples.