### PR TITLE
enable http access to the CDS.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -5,6 +5,6 @@ basic_scaling:
   idle_timeout: 30m
 handlers:
   - url: /.*
-    secure: always
-    redirect_http_response_code: 301
+#    secure: always
+#    redirect_http_response_code: 301
     script: auto


### PR DESCRIPTION
In order to enable access by some legacy services that don't have a smooth support for https, we need to enable http access to the CDS endpoint.