### PR TITLE
explicit content class in request leads to an explicit decision

### DIFF
--- a/lib/consent-processor.js
+++ b/lib/consent-processor.js
@@ -1,5 +1,6 @@
 const _ = require("lodash");
 const logger = require("./logger");
+const Obligations = require("./obligations");
 
 const {
   CONSENT_PERMIT,
@@ -118,9 +119,10 @@ async function consentDecision(entry, query) {
     const obligations =
       decision == CONSENT_PERMIT ? combineObligations(baseObligations) : [];
 
+    const adjustedDecision = adjustDecision(query, decision, obligations);
+
     return {
-      decision,
-      obligations,
+      ...adjustedDecision,
       dateTime: entry.resource.dateTime,
       id: entry.fullUrl
     };
@@ -134,6 +136,22 @@ async function consentDecision(entry, query) {
       id: entry.fullUrl
     };
   }
+}
+
+function adjustDecision(query, decision, obligations) {
+  const requestedContentClasses = _.castArray(query.class);
+  const redactedContentClass = Obligations.redactedContentClasses(obligations);
+
+  return _.intersectionWith(
+    requestedContentClasses,
+    redactedContentClass,
+    _.isEqual
+  ).length
+    ? {
+        decision: CONSENT_DENY,
+        obligations: []
+      }
+    : { decision, obligations };
 }
 
 function combineObligations(obligations) {

--- a/lib/consent-provisions.js
+++ b/lib/consent-provisions.js
@@ -87,6 +87,7 @@ async function processProvision(
 
   const match =
     matchPurposeOfUse(provision, query) && matchedActor && matchedClass;
+
   const obligations = match
     ? determineObligations(query, overarchingDecision, provision)
     : [];
@@ -99,7 +100,8 @@ async function processProvision(
 
 function determineObligations(query, decision, provision) {
   const securityLabels = _.castArray(provision.securityLabel);
-  const contentClasses = query.class ? [] : _.castArray(provision.class);
+  const contentClasses = _.castArray(provision.class);
+
   const clinicalCodes = _.castArray(_.get(provision, "code.coding"));
 
   const allCodes = _.concat(

--- a/lib/consent-valuesets.js
+++ b/lib/consent-valuesets.js
@@ -12,6 +12,13 @@ const POLICY_RULE = {
 const CONSENT_SCOPE_SYSTEM =
   "http://terminology.hl7.org/CodeSystem/consentscope";
 
+const CONTENT_CLASS_SYSTEMS = [
+  "http://ihe.net/fhir/ValueSet/IHE.FormatCode.codesystem",
+  "http://hl7.org/fhir/resource-types",
+  "urn:ietf:rfc:3986",
+  "urn:ietf:bcp:13"
+];
+
 const CONSENT_SCOPE = {
   PATIENT_PRIVACY: {
     system: CONSENT_SCOPE_SYSTEM,
@@ -65,7 +72,9 @@ module.exports = {
   POLICY_RULE,
   CONSENT_SCOPE,
   CONSENT_SCOPE_SYSTEM,
+  CONTENT_CLASS_SYSTEMS,
   PURPOSE_OF_USE_SYSTEM,
   PROVISION_TYPE,
-  CONSENT_OBLIGATIONS
+  CONSENT_OBLIGATIONS,
+  REDACT_CODE
 };

--- a/lib/obligations.js
+++ b/lib/obligations.js
@@ -1,0 +1,21 @@
+const _ = require("lodash");
+const CONSENT_VALUESETS = require("./consent-valuesets");
+
+function redactObligations(obligations) {
+  return obligations.filter(obligation =>
+    _.isEqual(obligation.id, CONSENT_VALUESETS.REDACT_CODE)
+  );
+}
+
+function redactedContentClasses(obligations) {
+  return _.flatten(
+    redactObligations(obligations).map(
+      obligation => obligation.parameters.codes
+    )
+  ).filter(code =>
+    CONSENT_VALUESETS.CONTENT_CLASS_SYSTEMS.includes(code.system)
+  );
+}
+module.exports = {
+  redactedContentClasses
+};

--- a/test/fixtures/consents/consent-boris-deny-restricted-content-class-and-sec-label.json
+++ b/test/fixtures/consents/consent-boris-deny-restricted-content-class-and-sec-label.json
@@ -1,0 +1,122 @@
+{
+  "resourceType": "Consent",
+  "status": "active",
+  "scope": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/consentscope",
+        "code": "patient-privacy"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "59284-6"
+        }
+      ]
+    }
+  ],
+  "patient": {
+    "reference": "Patient/52",
+    "display": "Betterhalf, Boris"
+  },
+  "dateTime": "2019-11-01",
+  "organization": [
+    {
+      "reference": "Organization/53"
+    }
+  ],
+  "policyRule": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "OPTIN"
+      }
+    ]
+  },
+  "provision": {
+    "period": {
+      "start": "2019-11-01",
+      "end": "2022-01-01"
+    },
+    "provision": [
+      {
+        "type": "deny",
+        "class": [
+          {
+            "system": "http://hl7.org/fhir/resource-types",
+            "code": "MedicationStatement"
+          }
+        ],
+        "actor": [
+          {
+            "role": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "IRCP"
+                }
+              ]
+            },
+            "reference": {
+              "reference": "Organization/54"
+            }
+          }
+        ],
+        "action": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/consentaction",
+                "code": "access"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "deny",
+        "securityLabel": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
+            "code": "R"
+          }
+        ],
+        "actor": [
+          {
+            "role": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "IRCP"
+                }
+              ]
+            },
+            "reference": {
+              "reference": "Organization/54"
+            }
+          }
+        ],
+        "action": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/consentaction",
+                "code": "access"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "system": "http://sdhealthconnect.github.io/leap/samples/ids",
+      "value": "consent-boris-deny-restricted-content-class"
+    }
+  ]
+}

--- a/test/lib/consent-processor.test.js
+++ b/test/lib/consent-processor.test.js
@@ -17,6 +17,7 @@ const ACTIVE_PRIVACY_CONSENT = BASE_CONSENT;
 const INACTIVE_PRIVACY_CONSENT = require("../fixtures/consents/consent-boris-inactive.json");
 const EXPIRED_PRIVACY_CONSENT = require("../fixtures/consents/consent-boris-expired.json");
 const CONSENT_DENY_PRACTITIONER = require("../fixtures/consents/consent-boris-deny-practitioner.json");
+const ACTIVE_PRIVACY_CONSENT_WITH_CONTENT_CLASS_PROVISION = require("../fixtures/consents/consent-boris-deny-restricted-content-class");
 
 const NOT_YET_VALID_PRIVACY_CONSENT = _.set(
   _.cloneDeep(BASE_CONSENT),
@@ -376,7 +377,6 @@ it("active optin consent with array of security label provisions", async () => {
 
 it("active optin consent with security label and content class provisions", async () => {
   expect.assertions(2);
-  const ACTIVE_PRIVACY_CONSENT_WITH_CONTENT_CLASS_PROVISION = require("../fixtures/consents/consent-boris-deny-restricted-content-class");
 
   setupMockOrganization(
     `/${_.get(
@@ -433,11 +433,11 @@ it("active optin consent with security label and content class provisions", asyn
 
 it("active optin consent with content class provisions and sec label with request including a class", async () => {
   expect.assertions(2);
-  const ACTIVE_PRIVACY_CONSENT_WITH_CONTENT_CLASS_PROVISION = require("../fixtures/consents/consent-boris-deny-restricted-content-class");
+  const ACTIVE_PRIVACY_CONSENT_WITH_CONTENT_CLASS_PROVISION_AND_SEC_LABEL = require("../fixtures/consents/consent-boris-deny-restricted-content-class-and-sec-label");
 
   setupMockOrganization(
     `/${_.get(
-      ACTIVE_PRIVACY_CONSENT_WITH_CONTENT_CLASS_PROVISION,
+      ACTIVE_PRIVACY_CONSENT_WITH_CONTENT_CLASS_PROVISION_AND_SEC_LABEL,
       "provision.provision[0].actor[0].reference.reference"
     )}`,
     ORGANIZATION,
@@ -448,7 +448,7 @@ it("active optin consent with content class provisions and sec label with reques
     [
       {
         fullUrl: `${CONSENT_FHIR_SERVERS[0]}/Consent/1`,
-        resource: ACTIVE_PRIVACY_CONSENT_WITH_CONTENT_CLASS_PROVISION
+        resource: ACTIVE_PRIVACY_CONSENT_WITH_CONTENT_CLASS_PROVISION_AND_SEC_LABEL
       }
     ],
     {
@@ -462,7 +462,7 @@ it("active optin consent with content class provisions and sec label with reques
       class: [
         {
           system: "http://hl7.org/fhir/resource-types",
-          code: "MedicationStatement"
+          code: "Immunization"
         }
       ]
     }
@@ -663,37 +663,6 @@ it("active optin consent with different scope", async () => {
   );
   expect(decision).toMatchObject({
     decision: "NO_CONSENT",
-    obligations: []
-  });
-});
-
-it("more recent consent takes precedence", async () => {
-  expect.assertions(1);
-
-  setupMockOrganization(
-    `/${_.get(
-      BASE_CONSENT,
-      "provision.provision[0].actor[0].reference.reference"
-    )}`,
-    ORGANIZATION,
-    2
-  );
-
-  const decision = await processDecision(
-    [
-      {
-        fullUrl: `${CONSENT_FHIR_SERVERS[0]}/Consent/1`,
-        resource: ACTIVE_PRIVACY_CONSENT
-      },
-      {
-        fullUrl: `${CONSENT_FHIR_SERVERS[0]}/Consent/2`,
-        resource: OLDER_ACTIVE_PRIVACY_OPTOUT_CONSENT
-      }
-    ],
-    QUERY.context
-  );
-  expect(decision).toMatchObject({
-    decision: "CONSENT_PERMIT",
     obligations: []
   });
 });


### PR DESCRIPTION
If the client specifies a content class explicitly, the response from the service will deny that request if it's prohibited by obligations. This enables the client to narrow down the scope of its request in return for an explicit response that does not include obligations.