### PR TITLE
rely on provision.type for the default decision 

### DIFF
--- a/lib/consent-processor.js
+++ b/lib/consent-processor.js
@@ -92,14 +92,13 @@ function denyOverrideDecisionCombiner(currentCandidate, thisDecision) {
 }
 
 async function consentDecision(entry, query) {
-  const rules = _.get(entry, "resource.policyRule.coding") || [];
-  const isOptIn = rules.some(rule => _.isEqual(rule, POLICY_RULE.OPTIN));
-  const isOptOut = rules.some(rule => _.isEqual(rule, POLICY_RULE.OPTOUT));
-  const baseDecision = isOptOut
-    ? CONSENT_DENY
-    : isOptIn
-    ? CONSENT_PERMIT
-    : NO_CONSENT;
+  const defaultDecision = _.get(entry, "resource.provision.type");
+  const baseDecision =
+    defaultDecision === "deny"
+      ? CONSENT_DENY
+      : defaultDecision === "permit"
+      ? CONSENT_PERMIT
+      : NO_CONSENT;
 
   const innerProvisions = _.castArray(
     _.get(entry, "resource.provision.provision")

--- a/test/fixtures/consents/consent-boris-deny-practitioner.json
+++ b/test/fixtures/consents/consent-boris-deny-practitioner.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2019-11-01",
       "end": "2022-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-deny-restricted-clinical-code.json
+++ b/test/fixtures/consents/consent-boris-deny-restricted-clinical-code.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2019-11-01",
       "end": "2022-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-deny-restricted-content-class-and-sec-label.json
+++ b/test/fixtures/consents/consent-boris-deny-restricted-content-class-and-sec-label.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2019-11-01",
       "end": "2022-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-deny-restricted-content-class-only.json
+++ b/test/fixtures/consents/consent-boris-deny-restricted-content-class-only.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2019-11-01",
       "end": "2022-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-deny-restricted-content-class.json
+++ b/test/fixtures/consents/consent-boris-deny-restricted-content-class.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2019-11-01",
       "end": "2022-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-deny-restricted-label.json
+++ b/test/fixtures/consents/consent-boris-deny-restricted-label.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2019-11-01",
       "end": "2022-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-expired.json
+++ b/test/fixtures/consents/consent-boris-expired.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2015-11-01",
       "end": "2016-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-inactive.json
+++ b/test/fixtures/consents/consent-boris-inactive.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2019-11-01",
       "end": "2022-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-optin.json
+++ b/test/fixtures/consents/consent-boris-optin.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2019-11-01",
       "end": "2022-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-optout.json
+++ b/test/fixtures/consents/consent-boris-optout.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTOUT"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2019-11-01",
       "end": "2022-01-01"
     },
+    "type": "deny",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-provision-array.json
+++ b/test/fixtures/consents/consent-boris-provision-array.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2019-11-01",
       "end": "2022-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",

--- a/test/fixtures/consents/consent-boris-research.json
+++ b/test/fixtures/consents/consent-boris-research.json
@@ -33,7 +33,7 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code": "OPTIN"
+        "code": "hipaa-self-pay"
       }
     ]
   },
@@ -42,6 +42,7 @@
       "start": "2015-11-01",
       "end": "2016-01-01"
     },
+    "type": "permit",
     "provision": [
       {
         "type": "deny",


### PR DESCRIPTION
For the default (seed) decision of the consent, we will use the `type` attribute of the root `provision`, instead of `policyRule` which is tied to a valueset that references the legislative framework in which the consent has been filed and does not provide an explicit computable default decision.

Note that this is a breaking change --all existing demo consents need to be updated to have a `type` attribute in the root `provision` set to `permit` or `deny` to reflect the default decision of the consent. 