### PR TITLE
remove the scope param from search when it's not given.

### DIFF
--- a/lib/consent-discovery.js
+++ b/lib/consent-discovery.js
@@ -34,11 +34,18 @@ async function fetchConsents(patientIdentifiers, consentScope) {
 }
 
 function resolveConsents(fhirBase, patientId, consentScope) {
-  const scope = consentScope || "";
+  const patientParam = {
+    patient: `Patient/${patientId}`
+  };
+  const scopeParam = consentScope
+    ? {
+        scope: consentScope
+      }
+    : null;
+  const params = { ...patientParam, ...scopeParam };
   return superagent
     .get(`${fhirBase}/Consent`)
-    .query({ patient: `Patient/${patientId}` })
-    .query({ scope: `${scope}` })
+    .query(params)
     .set({ Accept: "application/json" });
 }
 

--- a/test/common/setup-mock-consent-servers.js
+++ b/test/common/setup-mock-consent-servers.js
@@ -97,9 +97,43 @@ function setupMockConsent(scope, consent, index, patientId) {
   }
 }
 
+function setupMockConsentNoScope(consent, index, patientId) {
+  const fhirServerIndex = index || 0;
+  const fhirPatientId = patientId || "Patient/52";
+
+  const CONSENT_RESULTS_BUNDLE = consent
+    ? _.set(
+        _.set(
+          _.set(
+            _.clone(EMPTY_BUNDLE),
+            "entry[0].resource",
+            _.set(consent, "id", "1")
+          ),
+          "entry[0].fullUrl",
+          `${CONSENT_FHIR_SERVERS[0]}/Consent/1`
+        ),
+        "total",
+        1
+      )
+    : EMPTY_BUNDLE;
+
+  MOCK_FHIR_SERVERS[fhirServerIndex]
+    .get(`/Consent?patient=${fhirPatientId}`)
+    .reply(200, CONSENT_RESULTS_BUNDLE);
+
+  for (var i = 0; i < MOCK_FHIR_SERVERS.length; i++) {
+    if (i == index) continue;
+
+    MOCK_FHIR_SERVERS[i]
+      .get(`/Consent?patient=${fhirPatientId}`)
+      .reply(200, EMPTY_BUNDLE);
+  }
+}
+
 module.exports = {
   setupMockPatient,
   setupMockConsent,
+  setupMockConsentNoScope,
   setupMockOrganization,
   setupMockPractitioner,
   setupMockAuditEndpoint,

--- a/test/lib/consent-discovery.test.js
+++ b/test/lib/consent-discovery.test.js
@@ -6,6 +6,7 @@ const CONSENT = require("../fixtures/consents/consent-boris-optin.json");
 const {
   setupMockPatient,
   setupMockConsent,
+  setupMockConsentNoScope,
   MOCK_FHIR_SERVERS
 } = require("../common/setup-mock-consent-servers");
 
@@ -34,7 +35,7 @@ it("should return an array of consents from all servers without consent scope", 
   expect.assertions(1);
 
   setupMockPatient({ system: "ssn", value: "111111111" });
-  setupMockConsent("", CONSENT);
+  setupMockConsentNoScope(CONSENT);
 
   const consents = await fetchConsents([{ system: "ssn", value: "111111111" }]);
   expect(consents).toHaveLength(1);


### PR DESCRIPTION
Currently when scope is not given in the request, the LEAP-CDS will search for consent with a scope value of empty string leading to no results.