### PR TITLE
look for consent scope in category[0] and ignore matching scope if it…

### DIFF
--- a/lib/consent-processor.js
+++ b/lib/consent-processor.js
@@ -47,9 +47,16 @@ function isValid(entry) {
 }
 
 function matchesScope(entry, query) {
-  const scopes = _.get(entry, "resource.scope.coding") || [];
-  return scopes.some(scope =>
-    _.isEqual(scope, { system: CONSENT_SCOPE_SYSTEM, code: query.scope })
+  const scopes =
+    _.get(entry, "resource.scope.coding") ||
+    _.get(entry, "resource.category[0].coding") ||
+    [];
+
+  return (
+    !query.scope ||
+    scopes.some(scope =>
+      _.isEqual(scope, { system: CONSENT_SCOPE_SYSTEM, code: query.scope })
+    )
   );
 }
 

--- a/test/fixtures/consents/consent-boris-optin-with-scope-in-category.json
+++ b/test/fixtures/consents/consent-boris-optin-with-scope-in-category.json
@@ -1,0 +1,91 @@
+{
+  "resourceType": "Consent",
+  "status": "active",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/consentscope",
+          "code": "patient-privacy"
+        }
+      ]
+    },
+    {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "59284-6"
+        }
+      ]
+    }
+  ],
+  "patient": {
+    "reference": "Patient/52",
+    "display": "Betterhalf, Boris"
+  },
+  "dateTime": "2019-11-01",
+  "organization": [
+    {
+      "reference": "Organization/53"
+    }
+  ],
+  "policyRule": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "hipaa-self-pay"
+      }
+    ]
+  },
+  "provision": {
+    "period": {
+      "start": "2019-11-01",
+      "end": "2022-01-01"
+    },
+    "type": "permit",
+    "provision": [
+      {
+        "type": "deny",
+        "actor": [
+          {
+            "role": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "IRCP"
+                }
+              ]
+            },
+            "reference": {
+              "reference": "Organization/54"
+            }
+          }
+        ],
+        "action": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/consentaction",
+                "code": "access"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/consentaction",
+                "code": "correct"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "system": "http://sdhealthconnect.github.io/leap/samples/ids",
+      "value": "consent-boris-optin"
+    }
+  ]
+}

--- a/test/lib/consent-processor.test.js
+++ b/test/lib/consent-processor.test.js
@@ -15,6 +15,7 @@ const ORGANIZATION = require("../fixtures/organizations/org-good-health.json");
 
 const BASE_CONSENT = require("../fixtures/consents/consent-boris-optin.json");
 const ACTIVE_PRIVACY_CONSENT = BASE_CONSENT;
+const ACTIVE_PRIVACY_CONSENT_WITH_SCOPE_IN_CATEGORY = require("../fixtures/consents/consent-boris-optin-with-scope-in-category.json");
 const INACTIVE_PRIVACY_CONSENT = require("../fixtures/consents/consent-boris-inactive.json");
 const EXPIRED_PRIVACY_CONSENT = require("../fixtures/consents/consent-boris-expired.json");
 const CONSENT_DENY_PRACTITIONER = require("../fixtures/consents/consent-boris-deny-practitioner.json");
@@ -68,6 +69,61 @@ it("active optin consent", async () => {
   setupMockOrganization(
     `/${_.get(
       BASE_CONSENT,
+      "provision.provision[0].actor[0].reference.reference"
+    )}`,
+    ORGANIZATION
+  );
+
+  const decision = await processDecision(
+    [
+      {
+        fullUrl: `${CONSENT_FHIR_SERVERS[0]}/Consent/1`,
+        resource: ACTIVE_PRIVACY_CONSENT
+      }
+    ],
+    QUERY.context
+  );
+  expect(decision).toMatchObject({
+    decision: "CONSENT_PERMIT",
+    obligations: []
+  });
+});
+
+it("active optin consent with no scope in query", async () => {
+  expect.assertions(1);
+  setupMockAuditEndpoint();
+  setupMockOrganization(
+    `/${_.get(
+      BASE_CONSENT,
+      "provision.provision[0].actor[0].reference.reference"
+    )}`,
+    ORGANIZATION
+  );
+
+  const queryContext = _.clone(QUERY.context);
+  queryContext.scope = null;
+
+  const decision = await processDecision(
+    [
+      {
+        fullUrl: `${CONSENT_FHIR_SERVERS[0]}/Consent/1`,
+        resource: ACTIVE_PRIVACY_CONSENT
+      }
+    ],
+    queryContext
+  );
+  expect(decision).toMatchObject({
+    decision: "CONSENT_PERMIT",
+    obligations: []
+  });
+});
+
+it("active optin consent with scope stored in category[0]", async () => {
+  expect.assertions(1);
+  setupMockAuditEndpoint();
+  setupMockOrganization(
+    `/${_.get(
+      ACTIVE_PRIVACY_CONSENT_WITH_SCOPE_IN_CATEGORY,
       "provision.provision[0].actor[0].reference.reference"
     )}`,
     ORGANIZATION


### PR DESCRIPTION
- looks for consent scope in `category[0]` if `scope` is not present.
- if the CDS query doesn't include `scope` it processes all of the consents found regardless of their scope.