### PR TITLE
improve the accuracy of scope matching

### DIFF
--- a/lib/consent-processor.js
+++ b/lib/consent-processor.js
@@ -55,7 +55,10 @@ function matchesScope(entry, query) {
   return (
     !query.scope ||
     scopes.some(scope =>
-      _.isEqual(scope, { system: CONSENT_SCOPE_SYSTEM, code: query.scope })
+      _.isEqual(_.pick(scope, ["system", "code"]), {
+        system: CONSENT_SCOPE_SYSTEM,
+        code: query.scope
+      })
     )
   );
 }

--- a/test/fixtures/consents/consent-boris-optin-with-scope-in-category.json
+++ b/test/fixtures/consents/consent-boris-optin-with-scope-in-category.json
@@ -6,7 +6,8 @@
       "coding": [
         {
           "system": "http://terminology.hl7.org/CodeSystem/consentscope",
-          "code": "patient-privacy"
+          "code": "patient-privacy",
+          "display": "Privacy Consent"
         }
       ]
     },

--- a/test/fixtures/consents/consent-boris-optin.json
+++ b/test/fixtures/consents/consent-boris-optin.json
@@ -5,7 +5,8 @@
     "coding": [
       {
         "system": "http://terminology.hl7.org/CodeSystem/consentscope",
-        "code": "patient-privacy"
+        "code": "patient-privacy",
+        "display": "Privacy Consent"
       }
     ]
   },


### PR DESCRIPTION
Ensure that scope matching only looks at `system` and `code` and won't fail the match because of other optional attributes like `display`.