### PR TITLE
Feature/include consent references

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ The response object is similar to the following example:
               ]
             }
           }
-        ]
+        ],
+        "basedOn": "http://fhir.server.example/fhir/Consent/10023"
       }
     }
   ]
@@ -117,6 +118,7 @@ The `extension` attribute in the `card` contains a machine-readable object recor
 | :---             |     :---             | 
 | `decision`       | Same as the `summary` attribute discussed above.        |
 | `obligations`| An array of obligations (as discussed below) conveying additional requirements to be followed by the client.|
+|`basedOn` | The full URI of the consent resource based on which the decision has been made. Note that this is the URI from the Consent Decision Service's perspective and it may not be accessible to the client. |
 
 Each obligation object has an `id` attribute which identifies the obligation and a `parameters` attribute which specifies the parameters for the obligation. Currently, only the `REDACT` obligation from the [obligation policy valueset](https://www.hl7.org/fhir/v3/ObligationPolicy/vs.html) is supported and is used on `CONSENT_PERMIT` decisions with either of the following parameters:
 
@@ -131,9 +133,6 @@ The XACML interface is based on a limited implementation of the [XACML JSON Prof
 ```
 /xacml
 ```
-
-
-
 
 ### Request
 A `POST` request to this endpoint must have the header `Content-Type` set to `application/json` and have a body similar to the following example:

--- a/lib/consent-decision-card.js
+++ b/lib/consent-decision-card.js
@@ -48,6 +48,7 @@ const decisionToCardMap = {
 function asCard(consentDecision) {
   const card = _.cloneDeep(_.get(decisionToCardMap, consentDecision.decision));
   card.extension = _.pick(consentDecision, ["decision", "obligations"]);
+  card.extension.basedOn = consentDecision.fullId;
   return card;
 }
 

--- a/lib/consent-processor.js
+++ b/lib/consent-processor.js
@@ -23,11 +23,18 @@ async function processDecision(consentsBundle, query) {
 
   const consentDecisions = await Promise.all(consentDecisionPromises);
 
-  const finalDecision = consentDecisions.reduce(mostRecentDecisionCombiner, {
-    decision: NO_CONSENT,
-    obligations: [],
-    dateTime: "1970-01-01"
-  });
+  const applicableConsentDecisions = consentDecisions.filter(
+    aDecision => !_.isEqual(aDecision.decision, NO_CONSENT)
+  );
+
+  const finalDecision = applicableConsentDecisions.reduce(
+    mostRecentDecisionCombiner,
+    {
+      decision: NO_CONSENT,
+      obligations: [],
+      dateTime: "1970-01-01"
+    }
+  );
 
   await AuditService.maybeRecordAudit(finalDecision, query);
 
@@ -67,19 +74,11 @@ function matchesCategory(entry, query) {
 }
 
 function mostRecentDecisionCombiner(currentCandidate, thisConsentDecision) {
-  const thisConsentIsNotApplicable = _.isEqual(
-    thisConsentDecision.decision,
-    NO_CONSENT
-  );
   const thisConsentIsLessRecent =
     new Date(thisConsentDecision.dateTime) <
     new Date(currentCandidate.dateTime);
 
-  return thisConsentIsNotApplicable
-    ? currentCandidate
-    : thisConsentIsLessRecent
-    ? currentCandidate
-    : thisConsentDecision;
+  return thisConsentIsLessRecent ? currentCandidate : thisConsentDecision;
 }
 
 function denyOverrideDecisionCombiner(currentCandidate, thisDecision) {

--- a/test/controllers/patient-consent-consult.test.js
+++ b/test/controllers/patient-consent-consult.test.js
@@ -91,7 +91,8 @@ it("should return 200 and an array including a consent permit card with an OPTIN
         summary: "CONSENT_PERMIT",
         extension: {
           decision: "CONSENT_PERMIT",
-          obligations: []
+          obligations: [],
+          basedOn: "https://fhir-cdms1/base/Consent/1"
         }
       })
     ])
@@ -129,7 +130,8 @@ it("should return 200 and an array including a consent deny card with an OPTIN c
         summary: "CONSENT_DENY",
         extension: {
           decision: "CONSENT_DENY",
-          obligations: []
+          obligations: [],
+          basedOn: "https://fhir-cdms1/base/Consent/1"
         }
       })
     ])
@@ -161,7 +163,8 @@ it("should return 200 and an array including a consent deny card with an OPTOUT 
         summary: "CONSENT_DENY",
         extension: {
           decision: "CONSENT_DENY",
-          obligations: []
+          obligations: [],
+          basedOn: "https://fhir-cdms1/base/Consent/1"
         }
       })
     ])
@@ -222,7 +225,8 @@ it("should return 200 and an array including a consent permit card with obligati
                 ]
               }
             }
-          ]
+          ],
+          basedOn: "https://fhir-cdms1/base/Consent/1"
         }
       })
     ])


### PR DESCRIPTION
Include a reference to the consent based on which the decision has been made in the response (this is not implemented for the XACML endpoint due to the schema limitations of the XACML response).